### PR TITLE
Introducing KafkaIO.Read implementation compatibility testing

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -55,6 +55,8 @@ import org.apache.beam.sdk.expansion.ExternalTransformRegistrar;
 import org.apache.beam.sdk.io.Read.Unbounded;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
+import org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibility.KafkaIOReadImplementation;
+import org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibility.KafkaIOReadImplementationCompatibilityResult;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -1290,23 +1292,23 @@ public class KafkaIO {
       Coder<K> keyCoder = getKeyCoder(coderRegistry);
       Coder<V> valueCoder = getValueCoder(coderRegistry);
 
+      final KafkaIOReadImplementationCompatibilityResult compatibility =
+          KafkaIOReadImplementationCompatibility.getCompatibility(this);
+
       // For read from unbounded in a bounded manner, we actually are not going through Read or SDF.
       if (ExperimentalOptions.hasExperiment(
               input.getPipeline().getOptions(), "beam_fn_api_use_deprecated_read")
           || ExperimentalOptions.hasExperiment(
               input.getPipeline().getOptions(), "use_deprecated_read")
-          || getMaxNumRecords() < Long.MAX_VALUE
-          || getMaxReadTime() != null
-          || runnerRequiresLegacyRead(input.getPipeline().getOptions())) {
-        checkArgument(
-            getStopReadTime() == null,
-            "stopReadTime is set but it is only supported via SDF implementation.");
+          || compatibility.supportsOnly(KafkaIOReadImplementation.LEGACY)
+          || (compatibility.supports(KafkaIOReadImplementation.LEGACY)
+              && runnerPrefersLegacyRead(input.getPipeline().getOptions()))) {
         return input.apply(new ReadFromKafkaViaUnbounded<>(this, keyCoder, valueCoder));
       }
       return input.apply(new ReadFromKafkaViaSDF<>(this, keyCoder, valueCoder));
     }
 
-    private boolean runnerRequiresLegacyRead(PipelineOptions options) {
+    private boolean runnerPrefersLegacyRead(PipelineOptions options) {
       // Only Dataflow runner requires sdf read at this moment. For other non-portable runners, if
       // it doesn't specify use_sdf_read, it will use legacy read regarding to performance concern.
       // TODO(BEAM-10670): Remove this special check when we address performance issue.
@@ -1354,16 +1356,28 @@ public class KafkaIO {
       }
     }
 
-    private static class ReadFromKafkaViaUnbounded<K, V>
+    private abstract static class AbstractReadFromKafka<K, V>
         extends PTransform<PBegin, PCollection<KafkaRecord<K, V>>> {
       Read<K, V> kafkaRead;
       Coder<K> keyCoder;
       Coder<V> valueCoder;
 
-      ReadFromKafkaViaUnbounded(Read<K, V> kafkaRead, Coder<K> keyCoder, Coder<V> valueCoder) {
+      AbstractReadFromKafka(
+          Read<K, V> kafkaRead,
+          Coder<K> keyCoder,
+          Coder<V> valueCoder,
+          KafkaIOReadImplementation implementation) {
+        KafkaIOReadImplementationCompatibility.getCompatibility(kafkaRead)
+            .checkSupport(implementation);
         this.kafkaRead = kafkaRead;
         this.keyCoder = keyCoder;
         this.valueCoder = valueCoder;
+      }
+    }
+
+    private static class ReadFromKafkaViaUnbounded<K, V> extends AbstractReadFromKafka<K, V> {
+      ReadFromKafkaViaUnbounded(Read<K, V> kafkaRead, Coder<K> keyCoder, Coder<V> valueCoder) {
+        super(kafkaRead, keyCoder, valueCoder, KafkaIOReadImplementation.LEGACY);
       }
 
       @Override
@@ -1391,16 +1405,9 @@ public class KafkaIO {
       }
     }
 
-    static class ReadFromKafkaViaSDF<K, V>
-        extends PTransform<PBegin, PCollection<KafkaRecord<K, V>>> {
-      Read<K, V> kafkaRead;
-      Coder<K> keyCoder;
-      Coder<V> valueCoder;
-
+    static class ReadFromKafkaViaSDF<K, V> extends AbstractReadFromKafka<K, V> {
       ReadFromKafkaViaSDF(Read<K, V> kafkaRead, Coder<K> keyCoder, Coder<V> valueCoder) {
-        this.kafkaRead = kafkaRead;
-        this.keyCoder = keyCoder;
-        this.valueCoder = valueCoder;
+        super(kafkaRead, keyCoder, valueCoder, KafkaIOReadImplementation.SDF);
       }
 
       @Override

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1375,7 +1375,7 @@ public class KafkaIO {
       }
     }
 
-    private static class ReadFromKafkaViaUnbounded<K, V> extends AbstractReadFromKafka<K, V> {
+    static class ReadFromKafkaViaUnbounded<K, V> extends AbstractReadFromKafka<K, V> {
       ReadFromKafkaViaUnbounded(Read<K, V> kafkaRead, Coder<K> keyCoder, Coder<V> valueCoder) {
         super(kafkaRead, keyCoder, valueCoder, KafkaIOReadImplementation.LEGACY);
       }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibility.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibility.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import static org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibility.KafkaIOReadImplementation.LEGACY;
+import static org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibility.KafkaIOReadImplementation.SDF;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.CaseFormat;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.HashMultimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Multimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
+
+class KafkaIOReadImplementationCompatibility {
+
+  enum KafkaIOReadImplementation {
+    LEGACY,
+    SDF
+  }
+
+  @VisibleForTesting
+  @SuppressWarnings("ImmutableEnumChecker")
+  enum KafkaIOReadProperties {
+    CONSUMER_CONFIG,
+    TOPICS,
+    TOPIC_PARTITIONS,
+    KEY_CODER,
+    VALUE_CODER,
+    CONSUMER_FACTORY_FN,
+    WATERMARK_FN(LEGACY),
+    MAX_NUM_RECORDS(LEGACY) {
+      @Override
+      Object getDefaultValue() {
+        return Long.MAX_VALUE;
+      }
+    },
+    MAX_READ_TIME(LEGACY),
+    START_READ_TIME,
+    STOP_READ_TIME(SDF),
+    COMMIT_OFFSETS_IN_FINALIZE_ENABLED {
+      @Override
+      Object getDefaultValue() {
+        return false;
+      }
+    },
+    DYNAMIC_READ(SDF) {
+      @Override
+      Object getDefaultValue() {
+        return false;
+      }
+    },
+    WATCH_TOPIC_PARTITION_DURATION(SDF),
+    TIMESTAMP_POLICY_FACTORY,
+    OFFSET_CONSUMER_CONFIG,
+    KEY_DESERIALIZER_PROVIDER,
+    VALUE_DESERIALIZER_PROVIDER,
+    CHECK_STOP_READING_FN(SDF),
+    ;
+
+    @Nonnull private final ImmutableSet<KafkaIOReadImplementation> supportedImplementations;
+    @Nonnull private final Method getterMethod;
+
+    private KafkaIOReadProperties() {
+      this(KafkaIOReadImplementation.values());
+    }
+
+    private KafkaIOReadProperties(@Nonnull KafkaIOReadImplementation... supportedImplementations) {
+      this.supportedImplementations =
+          Sets.immutableEnumSet(Arrays.asList(supportedImplementations));
+      this.getterMethod = findGetterMethod(this);
+    }
+
+    private Method findGetterMethod(KafkaIOReadProperties property) {
+      final String propertyNameInUpperCamel =
+          CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, property.name());
+      try {
+        return KafkaIO.Read.class.getDeclaredMethod("get" + propertyNameInUpperCamel);
+      } catch (NoSuchMethodException e) {
+        try {
+          return KafkaIO.Read.class.getDeclaredMethod("is" + propertyNameInUpperCamel);
+        } catch (NoSuchMethodException e2) {
+          throw new RuntimeException("Should not happen", e);
+        }
+      }
+    }
+
+    @VisibleForTesting
+    Object getDefaultValue() {
+      return null;
+    }
+
+    @VisibleForTesting
+    Method getGetterMethod() {
+      return getterMethod;
+    }
+  }
+
+  static KafkaIOReadImplementationCompatibilityResult getCompatibility(KafkaIO.Read<?, ?> read) {
+    final Multimap<KafkaIOReadImplementation, KafkaIOReadProperties>
+        notSupportedImplementationsWithProperties = HashMultimap.create();
+    for (KafkaIOReadProperties property : KafkaIOReadProperties.values()) {
+      final EnumSet<KafkaIOReadImplementation> notSupportedImplementations =
+          EnumSet.complementOf(EnumSet.copyOf(property.supportedImplementations));
+      if (notSupportedImplementations.isEmpty()) {
+        // if we support every implementation we can skip this check
+        continue;
+      }
+      final Object defaultValue = property.getDefaultValue();
+      final Object currentValue;
+      try {
+        currentValue = property.getterMethod.invoke(read);
+      } catch (Exception e) {
+        throw new RuntimeException("Should not happen", e);
+      }
+      if (Objects.equals(defaultValue, currentValue)) {
+        // the defaultValue is always allowed,
+        // so there would be no compatibility issue
+        continue;
+      }
+      // the property has got a value, so we can't allow the not-supported implementations
+      for (KafkaIOReadImplementation notSupportedImplementation : notSupportedImplementations) {
+        notSupportedImplementationsWithProperties.put(notSupportedImplementation, property);
+      }
+    }
+    if (EnumSet.allOf(KafkaIOReadImplementation.class)
+        .equals(notSupportedImplementationsWithProperties.keySet())) {
+      throw new IllegalStateException(
+          "There is no Kafka read implementation that supports every configured property! "
+              + "Not supported implementations with the associated properties: "
+              + notSupportedImplementationsWithProperties);
+    }
+    return new KafkaIOReadImplementationCompatibilityResult(
+        notSupportedImplementationsWithProperties);
+  }
+
+  static class KafkaIOReadImplementationCompatibilityResult {
+    private final Multimap<KafkaIOReadImplementation, KafkaIOReadProperties> notSupported;
+
+    private KafkaIOReadImplementationCompatibilityResult(
+        Multimap<KafkaIOReadImplementation, KafkaIOReadProperties>
+            notSupportedImplementationsWithAssociatedProperties) {
+      this.notSupported = notSupportedImplementationsWithAssociatedProperties;
+    }
+
+    boolean supports(KafkaIOReadImplementation implementation) {
+      return !notSupported.containsKey(implementation);
+    }
+
+    boolean supportsOnly(KafkaIOReadImplementation implementation) {
+      return EnumSet.complementOf(EnumSet.of(implementation)).equals(notSupported.keySet());
+    }
+
+    void checkSupport(KafkaIOReadImplementation selectedImplementation) {
+      checkState(
+          supports(selectedImplementation),
+          "The current Kafka read configuration isn't supported by the "
+              + selectedImplementation
+              + " read implementation! "
+              + "Conflicting properties: "
+              + notSupported.get(selectedImplementation));
+    }
+  }
+}

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibilityTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibilityTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import static org.apache.beam.sdk.io.kafka.KafkaIOTest.mkKafkaReadTransform;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.io.kafka.KafkaIOReadImplementationCompatibility.KafkaIOReadProperties;
+import org.apache.beam.sdk.io.kafka.KafkaIOTest.ValueAsTimestampFn;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.CaseFormat;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class KafkaIOReadImplementationCompatibilityTest {
+
+  @Rule public final transient TestPipeline p = TestPipeline.create();
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testKafkaIOReadPropertiesEnumValuePresence() {
+    final Set<String> properties = getGetterPropertyNamesInUpperUnderscore(KafkaIO.Read.class);
+    final Set<String> enums = getEnumValueNamesInUpperUnderscore(KafkaIOReadProperties.class);
+
+    final Sets.SetView<String> missingEnums = Sets.difference(properties, enums);
+    final Sets.SetView<String> unnecessaryEnums = Sets.difference(enums, properties);
+
+    assertThat("There are missing 'KafkaIOReadProperties' enum values!", missingEnums, is(empty()));
+    assertThat(
+        "There are unnecessary 'KafkaIOReadProperties' enum values present!",
+        unnecessaryEnums,
+        is(empty()));
+  }
+
+  private static Set<String> getGetterPropertyNamesInUpperUnderscore(Class<?> clazz) {
+    final Set<String> result = Sets.newLinkedHashSet();
+    for (Method method : clazz.getDeclaredMethods()) {
+      if (!Modifier.isStatic(method.getModifiers())) {
+        if (!Void.TYPE.equals(method.getReturnType())) {
+          if (method.getParameterCount() == 0) {
+            for (String prefix : new String[] {"get", "is"}) {
+              final String methodName = method.getName();
+              if (methodName.startsWith(prefix) && methodName.length() > prefix.length()) {
+                final String propertyName = methodName.substring(prefix.length());
+                result.add(CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, propertyName));
+              }
+            }
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private static Set<String> getEnumValueNamesInUpperUnderscore(
+      Class<? extends Enum<?>> enumClazz) {
+    return Stream.of(enumClazz.getEnumConstants()).map(Enum::name).collect(Collectors.toSet());
+  }
+
+  @Test
+  public void testPrimitiveKafkaIOReadPropertiesDefaultValueExistence() {
+    for (KafkaIOReadProperties properties : KafkaIOReadProperties.values()) {
+      if (properties.getGetterMethod().getReturnType().isPrimitive()) {
+        assertThat(
+            "KafkaIOReadProperties." + properties + " should have a default value!",
+            properties.getDefaultValue(),
+            is(notNullValue()));
+      }
+    }
+  }
+
+  private void testReadTransformCreationWithImplementationBoundProperties(
+      Function<KafkaIO.Read<Integer, Long>, KafkaIO.Read<Integer, Long>> kafkaReadDecorator) {
+    p.apply(kafkaReadDecorator.apply(mkKafkaReadTransform(1000, null, new ValueAsTimestampFn())));
+    p.run();
+  }
+
+  private Function<KafkaIO.Read<Integer, Long>, KafkaIO.Read<Integer, Long>>
+      legacyDecoratorFunction() {
+    return read -> read.withMaxReadTime(Duration.millis(10));
+  }
+
+  private Function<KafkaIO.Read<Integer, Long>, KafkaIO.Read<Integer, Long>>
+      sdfDecoratorFunction() {
+    return read -> read.withStopReadTime(Instant.ofEpochMilli(10));
+  }
+
+  @Test
+  public void testReadTransformCreationWithLegacyImplementationBoundProperty() {
+    testReadTransformCreationWithImplementationBoundProperties(legacyDecoratorFunction());
+  }
+
+  @Test
+  public void testReadTransformCreationWithSdfImplementationBoundProperty() {
+    testReadTransformCreationWithImplementationBoundProperties(sdfDecoratorFunction());
+  }
+
+  @Test
+  public void testReadTransformCreationWithBothImplementationBoundProperties() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("every configured property");
+    thrown.expectMessage("Not supported implementations");
+    // SDF does not support maxReadTime
+    thrown.expectMessage("SDF");
+    thrown.expectMessage("MAX_READ_TIME");
+    // legacy does not support stopReadTime
+    thrown.expectMessage("LEGACY");
+    thrown.expectMessage("STOP_READ_TIME");
+
+    testReadTransformCreationWithImplementationBoundProperties(
+        legacyDecoratorFunction().andThen(sdfDecoratorFunction()));
+  }
+}

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -357,7 +357,7 @@ public class KafkaIOTest {
     }
   }
 
-  private static KafkaIO.Read<Integer, Long> mkKafkaReadTransform(
+  static KafkaIO.Read<Integer, Long> mkKafkaReadTransform(
       int numElements, @Nullable SerializableFunction<KV<Integer, Long>, Instant> timestampFn) {
     return mkKafkaReadTransform(numElements, numElements, timestampFn);
   }
@@ -366,9 +366,9 @@ public class KafkaIOTest {
    * Creates a consumer with two topics, with 10 partitions each. numElements are (round-robin)
    * assigned all the 20 partitions.
    */
-  private static KafkaIO.Read<Integer, Long> mkKafkaReadTransform(
+  static KafkaIO.Read<Integer, Long> mkKafkaReadTransform(
       int numElements,
-      int maxNumRecords,
+      @Nullable Integer maxNumRecords,
       @Nullable SerializableFunction<KV<Integer, Long>, Instant> timestampFn) {
 
     List<String> topics = ImmutableList.of("topic_a", "topic_b");
@@ -381,8 +381,10 @@ public class KafkaIOTest {
                 new ConsumerFactoryFn(
                     topics, 10, numElements, OffsetResetStrategy.EARLIEST)) // 20 partitions
             .withKeyDeserializer(IntegerDeserializer.class)
-            .withValueDeserializer(LongDeserializer.class)
-            .withMaxNumRecords(maxNumRecords);
+            .withValueDeserializer(LongDeserializer.class);
+    if (maxNumRecords != null) {
+      reader = reader.withMaxNumRecords(maxNumRecords);
+    }
 
     if (timestampFn != null) {
       return reader.withTimestampFn(timestampFn);
@@ -1007,8 +1009,7 @@ public class KafkaIOTest {
   }
 
   /** A timestamp function that uses the given value as the timestamp. */
-  private static class ValueAsTimestampFn
-      implements SerializableFunction<KV<Integer, Long>, Instant> {
+  static class ValueAsTimestampFn implements SerializableFunction<KV<Integer, Long>, Instant> {
     @Override
     public Instant apply(KV<Integer, Long> input) {
       return new Instant(input.getValue());


### PR DESCRIPTION
https://github.com/apache/beam/pull/15951 was the original trigger. During my tests the issue that I have encountered was that the graph and the behaviour during the actual execution differed from the one I would have expected strictly based on the `KafkaIO` configurations in the code. It happened due to multiple reasons, but this PR only aims to address one - for the rest see https://github.com/apache/beam/pull/16773 and https://github.com/apache/beam/pull/16888

So the current issue is that not every configration/property available at at the `KafkaIO.Read` works both with the legacy and the SDF implementation. On it's own this wouldn't be a problem, but unfortunately not every property was checked for this so you could configure it thinking it will work, but it won't and to make things ever worse without providing you any notice/warning about it. Also in certain scenarios the internal `PTransform` overrides replaced a working solution with another one that could result in lost functionality, because the new one might not support a feature - and to make this even worse this codepath could completely avoid any check in that regard.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nbali/beam/1)
<!-- Reviewable:end -->
